### PR TITLE
rest-dhcpd: create emty maps if no configuration is present

### DIFF
--- a/pkg/configdb/configdb.go
+++ b/pkg/configdb/configdb.go
@@ -40,9 +40,17 @@ var DB *Clients
 var Config *GlobalOptions
 
 func Init(configPath string) error {
-	content, err := os.ReadFile(path.Join(configPath, "rest-dhcpd-clients.json"))
-	if err != nil {
-		return err
+	content := []byte(`{}`)
+	dataFile := path.Join(configPath, "rest-dhcpd-clients.json")
+	_, err := os.Stat(dataFile)
+	if !os.IsNotExist(err) {
+		content, err = os.ReadFile(dataFile)
+		if err != nil {
+			return err
+		}
+	}
+	if len(content) == 0 {
+		content = []byte(`{}`)
 	}
 	err = json.Unmarshal(content, &DB)
 	if err != nil {

--- a/pkg/dhcpd/dhcpd.go
+++ b/pkg/dhcpd/dhcpd.go
@@ -72,7 +72,7 @@ func (h *DHCPHandler) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, options
 		client, id := rest.SearchForClientByMac(p.CHAddr().String())
 		if id != -1 { // If client exists in configdb, send a DHCPOFFER
 			h.options = lo.Assign(h.options, BuildOptions(client.Options)) // Merge global and client DHCP options
-			h.options[dhcp.OptionHostName] = []byte(client.Hostname) // Set hostname via DHCP options
+			h.options[dhcp.OptionHostName] = []byte(client.Hostname)       // Set hostname via DHCP options
 			log.Printf("Sending DHCPOFFER to %s with IP: %s.", p.CHAddr().String(), client.IP)
 			return dhcp.ReplyPacket(p, dhcp.Offer, h.ip, net.ParseIP(client.IP), h.leaseDuration,
 				h.options.SelectOrderOrAll(options[dhcp.OptionParameterRequestList]))

--- a/pkg/rest/rest.go
+++ b/pkg/rest/rest.go
@@ -113,6 +113,9 @@ func addClientConfig(config configdb.Client) {
 	log.Printf("Adding client config for: %s\n", config.MAC)
 	m := configdb.Mu{}
 	m.Mu.Lock()
+	if config.Options == nil {
+		config.Options = make(map[string]interface{})
+	}
 	configdb.DB.Clients = append(configdb.DB.Clients, config)
 	m.Mu.Unlock()
 	err := m.Save()
@@ -125,6 +128,9 @@ func updateClientConfig(id int, config configdb.Client) {
 	log.Printf("Updating client config for: %s\n", config.MAC)
 	m := configdb.Mu{}
 	m.Mu.Lock()
+	if config.Options == nil {
+		config.Options = make(map[string]interface{})
+	}
 	configdb.DB.Clients[id].IP = config.IP
 	configdb.DB.Clients[id].Hostname = config.Hostname
 	configdb.DB.Clients[id].Options = config.Options


### PR DESCRIPTION
Check if config file exist, also check if options are present. If not, create empty maps.
We do not want nil values in json db.

@vinted/sre 