### PR TITLE
Remove unused packages

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,10 +1,9 @@
 FROM golang:1.19.6-alpine3.17
 
 WORKDIR /code
-RUN apk --no-cache add gcc git musl-dev openssh
+RUN apk --no-cache add gcc musl-dev && \
+    wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.1
 
 COPY go.mod go.sum ./
+COPY . /code/
 
-RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.1
-
-COPY . /code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.test
-    volumes:
-      - ~/.ssh:/root/.ssh:ro
     command: >
       sh -c "set -o pipefail &&
              go mod download &&


### PR DESCRIPTION
Packages `git` and `openssh` are not used here, same goes for `.ssh` dir in docker-compose file. Also it seems there's a Dockerfile for running linters and tests, but not for building a binary.

I would also consider including build instructions in the README.md file since the project is structured in a way that doing `go build` does not produce any binaries.