### PR TITLE
Remove unnecessary pipefail option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh:ro
     command: >
-      sh -c "set -o pipefail &&
-             go mod download &&
+      sh -c "go mod download &&
              ./bin/golangci-lint run -v &&
              go test ./..."


### PR DESCRIPTION
Shell option `pipefail` only affects commands with pipes, it's not needed in this case.