### PR TITLE
Fix log.Fatal usage

### DIFF
--- a/cmd/rest-dhcpd/main.go
+++ b/cmd/rest-dhcpd/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"flag"
+	"log"
+
 	"github.com/vinted/rest-dhcpd/pkg/configdb"
 	"github.com/vinted/rest-dhcpd/pkg/dhcpd"
 	"github.com/vinted/rest-dhcpd/pkg/rest"
-	"log"
-	"os"
 )
 
 func main() {
@@ -15,8 +15,7 @@ func main() {
 	flag.Parse()
 	err := configdb.Init(configPath)
 	if err != nil {
-		log.Fatal("Failed to read configuration. %w", err)
-		os.Exit(1)
+		log.Fatalf("Failed to read configuration. %v", err)
 	}
 	go rest.StartServer()
 	dhcpd.StartServer()

--- a/pkg/dhcpd/dhcpd.go
+++ b/pkg/dhcpd/dhcpd.go
@@ -2,17 +2,18 @@ package dhcpd
 
 import (
 	"fmt"
+	"log"
+	"net"
+	"reflect"
+	"strconv"
+	"time"
+
 	dhcp "github.com/krolaw/dhcp4"
 	"github.com/krolaw/dhcp4/conn"
 	"github.com/samber/lo"
 	"github.com/vinted/rest-dhcpd/pkg/configdb"
 	"github.com/vinted/rest-dhcpd/pkg/prometheus"
 	"github.com/vinted/rest-dhcpd/pkg/rest"
-	"log"
-	"net"
-	"reflect"
-	"strconv"
-	"time"
 )
 
 type DHCPHandler struct {
@@ -45,7 +46,7 @@ func StartServer() {
 	}
 	cn, err := conn.NewUDP4BoundListener(configdb.Config.ListenInterface, ":67")
 	if err != nil {
-		log.Fatal("Failed to bind to interface. %w", err)
+		log.Fatalf("Failed to bind to interface. %v", err)
 	}
 	log.Fatal(dhcp.Serve(cn, handler))
 }


### PR DESCRIPTION
`log.Fatal` already calls `os.Exit` so another one is not needed. Also not sure what the intent was with the `%w` verb, but it seems that an incorrect method or verb was used here, and it probably doesn't output the expected result (https://go.dev/play/p/88AG2pDSC4_-?v=goprev) 