### PR TITLE
Add multi-interface support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,30 +9,56 @@ Global server configuration is stored in `rest-dhcpd-config.json` file:
 
 ```
 {
-    "IP": "192.168.100.1",
     "LeaseDuration": 30,
     "AuthToken": "secretToken",
-    "ListenInterface": "virbr1",
     "HTTPListenAddress": "127.0.0.1:6767",
     "TLSEnabled": true,
     "TLSPrivateKeyFile": "example.key",
     "TLSCertificateFile": "example.crt",
     "Options": {
-      "1": "255.255.255.0",
-      "3": "192.168.100.1",
-      "6": "10.32.0.3"
-    }
+      "6": ["1.1.1.1", "8.8.8.8"]
+    },
+    "Interfaces": [
+      {
+        "Name": "virbr1",
+        "IP": "192.168.100.1",
+        "Options": {
+          "1": "255.255.255.0",
+          "3": "192.168.100.1"
+        }
+      },
+      {
+        "Name": "virbr2",
+        "IP": "10.0.0.1",
+        "LeaseDuration": 3600,
+        "Options": {
+          "1": "255.255.0.0",
+          "3": "10.0.0.1"
+        }
+      }
+    ]
 }
 ```
-`IP` - IP address of DHCP server.  
-`LeaseDuration` - DHCP lease duration in seconds.  
-`AuthToken` - authentication token for REST interface.  
-`ListenInterface` - network interface to listen fro DHCP requests.  
-`HTTPListenAddress` - address to listen fro HTTP requests. To listen on all network addresses use port without any IP address `:6767`.  
-`TLSEnabled` - start REST interface with HTTPS support.  
-`TLSPrivateKeyFile` - private key file for HTTPS support.  
-`TLSCertificateFile` - certificate file for HTTPS support.  
-`Options` - list of global DHCP options. Can be overridden by client config.  
+
+- `LeaseDuration` - default DHCP lease duration in seconds. Used by any interface that does not set its own.
+- `AuthToken` - authentication token for REST interface.
+- `HTTPListenAddress` - address to listen for HTTP requests. To listen on all network addresses use port without any IP address `:6767`.
+- `TLSEnabled` - start REST interface with HTTPS support.
+- `TLSPrivateKeyFile` - private key file for HTTPS support.
+- `TLSCertificateFile` - certificate file for HTTPS support.
+- `Options` - top-level DHCP options applied to every interface as defaults. Per-interface `Options` override these per option key, and per-client `Options` override both.
+- `Interfaces` - list of interfaces to listen on. Must contain at least one entry. Each entry has:
+  - `Name` - network interface name (e.g. `virbr1`).
+  - `IP` - IP address of the DHCP server on this interface (used as the server identifier in responses).
+  - `LeaseDuration` - optional lease duration override for this interface. If omitted, the top-level value is used.
+  - `Options` - DHCP options specific to this subnet. Merged on top of the top-level `Options`.
+
+Requests are served by whichever interface received them; the response uses that interface's `IP` and its merged option set.
+
+#### Migration from single-interface configs
+If upgrading from a version with top-level `IP` and `ListenInterface`, move those values into a one-element `Interfaces` array along with the subnet-specific entries from `Options`. Any options shared across interfaces (e.g. DNS) can stay at the top level as defaults.
+
+For backwards compatibility, the legacy top-level `IP` and `ListenInterface` fields are still accepted: if `Interfaces` is omitted and these fields are set, a single-entry `Interfaces` array is synthesized from them at startup and a deprecation warning is logged. Configs that set both forms are rejected.
 
 ### Basics
 REST DHCP server does not provide dynamic DHCP leases. It only provides leases to configured clients.

--- a/pkg/configdb/configdb.go
+++ b/pkg/configdb/configdb.go
@@ -2,7 +2,9 @@ package configdb
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
+	"net"
 	"os"
 	"path"
 	"sync"
@@ -12,17 +14,27 @@ type Mu struct {
 	Mu sync.Mutex
 }
 
+type InterfaceConfig struct {
+	Name          string
+	IP            string
+	LeaseDuration int
+	Options       interface{}
+}
+
 type GlobalOptions struct {
-	IP                 string
-	Gateway            string
 	LeaseDuration      int
 	AuthToken          string
-	ListenInterface    string
 	HTTPListenAddress  string
 	TLSEnabled         bool
 	TLSPrivateKeyFile  string
 	TLSCertificateFile string
 	Options            interface{}
+	Interfaces         []InterfaceConfig
+
+	// Deprecated single-interface fields. Kept for backwards compatibility
+	// with pre-multi-interface configs. Use Interfaces[] instead.
+	IP              string
+	ListenInterface string
 }
 
 type Clients struct {
@@ -74,7 +86,40 @@ func Init(configPath string) error {
 	if err != nil {
 		return err
 	}
+	if err := validateConfig(Config); err != nil {
+		return err
+	}
 	log.Printf("DB init done.")
+	return nil
+}
+
+func validateConfig(c *GlobalOptions) error {
+	legacyPresent := c.ListenInterface != "" || c.IP != ""
+	if len(c.Interfaces) > 0 && legacyPresent {
+		return fmt.Errorf("config: cannot use both legacy IP/ListenInterface and Interfaces[]; pick one")
+	}
+	if len(c.Interfaces) == 0 && legacyPresent {
+		log.Printf("config: top-level IP/ListenInterface are deprecated; please migrate to Interfaces[]")
+		c.Interfaces = []InterfaceConfig{{Name: c.ListenInterface, IP: c.IP}}
+	}
+	if len(c.Interfaces) == 0 {
+		return fmt.Errorf("config: Interfaces must contain at least one entry")
+	}
+	for i := range c.Interfaces {
+		iface := &c.Interfaces[i]
+		if iface.Name == "" {
+			return fmt.Errorf("config: Interfaces[%d].Name is empty", i)
+		}
+		if net.ParseIP(iface.IP).To4() == nil {
+			return fmt.Errorf("config: Interfaces[%d] (%s) has invalid IPv4 address %q", i, iface.Name, iface.IP)
+		}
+		if iface.LeaseDuration == 0 {
+			iface.LeaseDuration = c.LeaseDuration
+		}
+		if iface.LeaseDuration == 0 {
+			return fmt.Errorf("config: Interfaces[%d] (%s) has no LeaseDuration and no top-level default is set", i, iface.Name)
+		}
+	}
 	return nil
 }
 

--- a/pkg/dhcpd/dhcpd.go
+++ b/pkg/dhcpd/dhcpd.go
@@ -17,6 +17,7 @@ import (
 )
 
 type DHCPHandler struct {
+	interfaceName string
 	ip            net.IP
 	leaseDuration time.Duration
 	options       dhcp.Options
@@ -38,22 +39,38 @@ var data_type = map[int]string{
 }
 
 func StartServer() {
-	lease, _ := time.ParseDuration(strconv.Itoa(configdb.Config.LeaseDuration) + "s")
-	handler := &DHCPHandler{
-		ip:            net.ParseIP(configdb.Config.IP).To4(),
-		leaseDuration: lease,
-		options:       BuildOptions(configdb.Config.Options),
+	globalOptions := BuildOptions(configdb.Config.Options)
+	errCh := make(chan error, len(configdb.Config.Interfaces))
+
+	for _, iface := range configdb.Config.Interfaces {
+		lease, _ := time.ParseDuration(strconv.Itoa(iface.LeaseDuration) + "s")
+		handler := &DHCPHandler{
+			interfaceName: iface.Name,
+			ip:            net.ParseIP(iface.IP).To4(),
+			leaseDuration: lease,
+			options:       lo.Assign(globalOptions, BuildOptions(iface.Options)),
+		}
+		cn, err := conn.NewUDP4BoundListener(iface.Name, ":67")
+		if err != nil {
+			log.Fatalf("Failed to bind to interface %s: %v", iface.Name, err)
+		}
+		log.Printf("[%s] Listening for DHCP requests (server IP %s).", iface.Name, handler.ip)
+		go func(name string) {
+			errCh <- fmt.Errorf("[%s] serve exited: %w", name, dhcp.Serve(cn, handler))
+		}(iface.Name)
 	}
-	cn, err := conn.NewUDP4BoundListener(configdb.Config.ListenInterface, ":67")
-	if err != nil {
-		log.Fatalf("Failed to bind to interface. %v", err)
-	}
-	log.Fatal(dhcp.Serve(cn, handler))
+	log.Fatal(<-errCh)
 }
 
 func BuildOptions(options interface{}) dhcp.Options {
-	opt := options.(map[string]interface{})
 	dhcp_opt := dhcp.Options{}
+	if options == nil {
+		return dhcp_opt
+	}
+	opt, ok := options.(map[string]interface{})
+	if !ok {
+		return dhcp_opt
+	}
 	for key, value := range opt {
 		var val []byte
 		id, _ := strconv.Atoi(key)
@@ -77,18 +94,18 @@ func (h *DHCPHandler) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, options
 	switch msgType {
 
 	case dhcp.Discover:
-		log.Printf("DHCPDISCOVER from %s", p.CHAddr().String())
+		log.Printf("[%s] DHCPDISCOVER from %s", h.interfaceName, p.CHAddr().String())
 		prometheus.UpdateDHCPDiscover()
 		client, id := rest.SearchForClientByMac(p.CHAddr().String())
 		if id != -1 { // If client exists in configdb, send a DHCPOFFER
-			h.options = lo.Assign(h.options, BuildOptions(client.Options)) // Merge global and client DHCP options
-			h.options[dhcp.OptionHostName] = []byte(client.Hostname)       // Set hostname via DHCP options
-			log.Printf("Sending DHCPOFFER to %s with IP: %s.", p.CHAddr().String(), client.IP)
+			var reqOptions dhcp.Options = lo.Assign(h.options, BuildOptions(client.Options))
+			reqOptions[dhcp.OptionHostName] = []byte(client.Hostname)
+			log.Printf("[%s] Sending DHCPOFFER to %s with IP: %s.", h.interfaceName, p.CHAddr().String(), client.IP)
 			prometheus.UpdateDHCPOffer()
 			return dhcp.ReplyPacket(p, dhcp.Offer, h.ip, net.ParseIP(client.IP), h.leaseDuration,
-				h.options.SelectOrderOrAll(options[dhcp.OptionParameterRequestList]))
+				reqOptions.SelectOrderOrAll(options[dhcp.OptionParameterRequestList]))
 		} else {
-			log.Printf("Server %s is not in configdb.", p.CHAddr().String())
+			log.Printf("[%s] Client %s is not in configdb.", h.interfaceName, p.CHAddr().String())
 			prometheus.UpdateDHCPNoSuchLease()
 		}
 	case dhcp.Request:
@@ -102,25 +119,27 @@ func (h *DHCPHandler) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, options
 			if reqIP == nil { // DHCPREQUEST does not have IP address if it's a lease renew. IP address is set in CIADDR space instead.
 				reqIP = net.IP(p.CIAddr())
 			}
-			log.Printf("DHCPREQUEST from %s: IP: %s.", p.CHAddr().String(), reqIP.String())
+			log.Printf("[%s] DHCPREQUEST from %s: IP: %s.", h.interfaceName, p.CHAddr().String(), reqIP.String())
 			if client.IP == reqIP.String() {
-				log.Printf("Sending DHCPACK to %s with IP: %s.", p.CHAddr().String(), reqIP.String())
+				var reqOptions dhcp.Options = lo.Assign(h.options, BuildOptions(client.Options))
+				reqOptions[dhcp.OptionHostName] = []byte(client.Hostname)
+				log.Printf("[%s] Sending DHCPACK to %s with IP: %s.", h.interfaceName, p.CHAddr().String(), reqIP.String())
 				prometheus.UpdateDHCPACK()
 				return dhcp.ReplyPacket(p, dhcp.ACK, h.ip, reqIP, h.leaseDuration,
-					h.options.SelectOrderOrAll(options[dhcp.OptionParameterRequestList]))
+					reqOptions.SelectOrderOrAll(options[dhcp.OptionParameterRequestList]))
 			} else {
-				log.Printf("Requested IP %s from %s does not match configdb, sending NAK.", reqIP.String(), p.CHAddr().String())
+				log.Printf("[%s] Requested IP %s from %s does not match configdb, sending NAK.", h.interfaceName, reqIP.String(), p.CHAddr().String())
 				prometheus.UpdateDHCPNAK()
 				return dhcp.ReplyPacket(p, dhcp.NAK, h.ip, nil, 0, nil)
 			}
 		} else {
-			log.Printf("Server %s is not in configdb.", p.CHAddr().String())
+			log.Printf("[%s] Client %s is not in configdb.", h.interfaceName, p.CHAddr().String())
 			prometheus.UpdateDHCPNoSuchLease()
 		}
 	case dhcp.Release:
-		log.Printf("DHCPRELEASE from %s. Ignoring.", p.CHAddr().String())
+		log.Printf("[%s] DHCPRELEASE from %s. Ignoring.", h.interfaceName, p.CHAddr().String())
 	case dhcp.Decline:
-		log.Printf("DHCPDECLINE from %s. Ignoring.", p.CHAddr().String())
+		log.Printf("[%s] DHCPDECLINE from %s. Ignoring.", h.interfaceName, p.CHAddr().String())
 	}
 	return nil
 }

--- a/rest-dhcpd-config.json
+++ b/rest-dhcpd-config.json
@@ -1,15 +1,30 @@
 {
-    "IP": "192.168.100.1",
     "LeaseDuration": 30,
     "AuthToken": "secretToken",
-    "ListenInterface": "virbr1",
     "HTTPListenAddress": "127.0.0.1:6767",
     "TLSEnabled": true,
     "TLSPrivateKeyFile": "example.key",
     "TLSCertificateFile": "example.crt",
     "Options": {
-      "1": "255.255.255.0",
-      "3": "192.168.100.1",
       "6": ["1.1.1.1", "8.8.8.8"]
-    }
+    },
+    "Interfaces": [
+      {
+        "Name": "virbr1",
+        "IP": "192.168.100.1",
+        "Options": {
+          "1": "255.255.255.0",
+          "3": "192.168.100.1"
+        }
+      },
+      {
+        "Name": "virbr2",
+        "IP": "10.0.0.1",
+        "LeaseDuration": 3600,
+        "Options": {
+          "1": "255.255.0.0",
+          "3": "10.0.0.1"
+        }
+      }
+    ]
 }


### PR DESCRIPTION
Allow rest-dhcpd to listen on multiple interfaces, this includes:
- having separate Options, lease durations and IPs per interface
- having global Options field that is merged with per interface Options field, per-interface Option field takes precedence.
- this is backwarads compatible with previous single interface configs, only a deprecation log message is printed if legacy config is detected

@vinted/sre-foundations 